### PR TITLE
Make disabling build_failure_weight_multiplier optional.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -609,3 +609,20 @@ options:
       override YAML files in the service's policy.d directory.  The resource
       file should be a ZIP file containing at least one yaml file with a .yaml
       or .yml extension.  If False then remove the overrides.
+  skip-hosts-with-build-failures:  # LP: 1892934
+    type: boolean
+    default: False  # LP: 1818239
+    description: |
+      Allow the scheduler to avoid building instances on hosts that had recent
+      build failures.
+      .
+      Since it is generally possible for an end user to cause build failures -
+      for example by providing a bad image - and maliciously reduce the pool of
+      available hypervisors, this option is disabled by default.
+      .
+      Enable to allow the scheduler to work around malfunctioning computes and
+      favor instance build reliability, at the cost of a potentially uneven
+      cloud utilization.
+      .
+      Note: only effective from Pike onward
+

--- a/hooks/nova_cc_context.py
+++ b/hooks/nova_cc_context.py
@@ -407,6 +407,8 @@ class NovaConfigContext(ch_context.WorkerConfigContext):
             ctxt['enable_sriov_nic_selection'] = \
                 hookenv.config('enable-sriov-nic-selection')
 
+        ctxt['skip_hosts_with_build_failures'] = hookenv.config(
+            'skip-hosts-with-build-failures')
         return ctxt
 
 

--- a/templates/pike/nova.conf
+++ b/templates/pike/nova.conf
@@ -206,12 +206,14 @@ enabled_filters = {{ scheduler_default_filters }},{{ additional_neutron_filters 
 enabled_filters = {{ scheduler_default_filters }}
 {% endif %}
 
+{% if not skip_hosts_with_build_failures %}
 # Disable BuildFailureWeigher as any failed build will result
 # in a very low weighting for the hypervisor, resulting in
 # instances all being scheduled to hypervisors with no build
 # failures.
 # https://bugs.launchpad.net/charm-nova-cloud-controller/+bug/1818239
 build_failure_weight_multiplier = 0.0
+{% endif %}
 
 [api]
 auth_strategy=keystone

--- a/templates/rocky/nova.conf
+++ b/templates/rocky/nova.conf
@@ -207,12 +207,14 @@ enabled_filters = {{ scheduler_default_filters }},{{ additional_neutron_filters 
 enabled_filters = {{ scheduler_default_filters }}
 {% endif %}
 
+{% if not skip_hosts_with_build_failures %}
 # Disable BuildFailureWeigher as any failed build will result
 # in a very low weighting for the hypervisor, resulting in
 # instances all being scheduled to hypervisors with no build
 # failures.
 # https://bugs.launchpad.net/charm-nova-cloud-controller/+bug/1818239
 build_failure_weight_multiplier = 0.0
+{% endif %}
 
 [api]
 auth_strategy=keystone

--- a/unit_tests/test_nova_cc_contexts.py
+++ b/unit_tests/test_nova_cc_contexts.py
@@ -379,6 +379,8 @@ class NovaComputeContextTests(CharmTestCase):
                          self.config('console-access-protocol'))
         self.assertEqual(ctxt['console_access_port'],
                          self.config('console-access-port'))
+        self.assertEqual(ctxt['skip_hosts_with_build_failures'],
+                         self.config('skip-hosts-with-build-failures'))
 
     _pci_alias1 = {
         "name": "IntelNIC",


### PR DESCRIPTION
This commit introduces a new charm option allowing operators to override
the hardcoded 0.0 that disabled hypervisor demotion on build failures
from pike onward.

In certain environments it may be preferable to retain the upstream
behavior of letting the scheduler work around malfunctional computes and
favor instance building reliability at the cost of a potentially uneven
load distribution.

Cherry-picking this change from Change-Id
I2faa5ab8cd505a9d61a9fa26e1b08d16b0c795fb onto stable/19.10

Change-Id: I2faa5ab8cd505a9d61a9fa26e1b08d16b0c795fb
Closes-Bug: 1892934